### PR TITLE
Added Github workflow for building an implementation guide

### DIFF
--- a/.github/workflows/consent-gh-pages.yml
+++ b/.github/workflows/consent-gh-pages.yml
@@ -1,0 +1,58 @@
+name: Consent-gh-pages
+
+on:
+  workflow_dispatch:
+
+env:
+  IG: Consent
+
+# The following jobs are equal for all IGs and can be moved to a common composite-action if 'uses'-support is added, see:
+# https://github.com/actions/runner/blob/main/docs/adrs/1144-composite-actions.md
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # Persist the FHIR Package Cache between runners.
+      # Doc: https://confluence.hl7.org/display/FHIR/FHIR+Package+Cache
+      - name: 🗂️ Cache FHIR Packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.fhir/packages
+          key: fhir-packages
+
+      # Persist the IG Publisher input-cache between runners.
+      # Doc: https://build.fhir.org/ig/FHIR/ig-guidance/using-templates.html#igroot-input-cache
+      - name: 🗂️ Cache IG Publisher input-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ env.IG }}/input-cache
+          key: ig-publisher-input-cache           
+      
+      # NPM and no-basis package
+      - name: NPM install no-basis
+        run: npm --registry https://packages.simplifier.net install hl7.fhir.no.basis@2.1.1
+
+      # Downloads the newest version of the IG Publisher, this could probable be cached.
+      - name: 📥 Download IG Publisher
+        run: wget -q https://github.com/HL7/fhir-ig-publisher/releases/latest/download/publisher.jar
+
+      # Builds the HTML page for the IG.
+      - name: 🏃‍♂️ Run IG Publisher
+        uses: docker://hl7fhir/ig-publisher-base:latest
+        with:
+          args: java -jar publisher.jar publisher -ig ig.ini
+
+      # Publishes the HTML page to a seperate branch in order to host it using GitHub-Pages.
+      # This will overwrite the currently published HTML page.
+      - name: 🚀 Deploy to GitHub-Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: output
+          destination_dir: currentbuild
+          exclude_assets: '**.zip,**.tgz,**.pack'
+          commit_message: '${{ env.IG }}: ${{ github.event.head_commit.message }}'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*/fsh-generated
+*/input-cache
+*/output
+*/temp
+*/template
+*/_preprocessed
+*/_genonce*
+*/_updatePublisher*

--- a/ig.ini
+++ b/ig.ini
@@ -1,3 +1,3 @@
 [IG]
-ig = fsh-generated/resources/ImplementationGuide-fhir.consent.json
+ig = fsh-generated/resources/ImplementationGuide-hso.fhir.no.consent.json
 template = fhir.base.template#current

--- a/package-list.json
+++ b/package-list.json
@@ -1,0 +1,14 @@
+{
+	"package-id" : "hso.fhir.no.consent",
+    "title" :  "Profiles for FHIR R4 Consent",
+    "canonical" : "http://hso.no/fhir", 
+    "introduction" : "md",
+    "category" : "Clinical Records",
+	"list" : [{
+		"version" : "current",
+		"desc" : "Continuous Integration Build (latest in version control)",
+		"path" : "http://build.fhir.org/ig/HL7/xxx",
+		"status" : "ci-build",
+		"current" : true
+	}]
+}

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -3,8 +3,8 @@
 # │  used properties are included. For a list of all supported properties and their functions,     │
 # │  see: https://fshschool.org/docs/sushi/configuration/.                                         │
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
-id: fhir.consent
-canonical: http://example.org
+id: hso.fhir.no.consent
+canonical: http://hso.no/fhir
 name: ConsentManagement
 title: Consent management to withhold or withdraw consent for disclosure
 # description: Example Implementation Guide for getting started with SUSHI
@@ -15,11 +15,8 @@ copyrightYear: 2022+
 releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
 # license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 # jurisdiction: urn:iso:std:iso:3166#US "United States of America" # https://www.hl7.org/fhir/valueset-jurisdiction.html
-publisher:
-  name: Example Publisher
-  url: http://example.org/example-publisher
-  # email: test@example.org
-
+dependencies:
+    hl7.fhir.no.basis: 2.1.1
 # The dependencies property corresponds to IG.dependsOn. The key is the
 # package id and the value is the version (or dev/current). For advanced
 # use cases, the value can be an object with keys for id, uri, and version.


### PR DESCRIPTION
## Added IG builder script to the Consent project

Updated **sushi-config.yaml** and **ig.ini**
* The id and canonical is only guesswork on my part but it is possible to change this later

Added **.gitignore**
Added worflow script for IG build **consent-gh-pages.yml**
Added **package-list.json** to track development of the published versions